### PR TITLE
ci: 배포 자동화를 위한 파일 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+          settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Gradle Build
+        run: ./gradlew build
+
+      - name: Gradle Test
+        run: ./gradlew test
+
+      - name: Docker build
+        run: |
+          sudo docker build -t dev-share .
+          sudo docker login -u ${{ secrets.USERNAME }} -p ${{ secrets.PASSWORD }}
+          sudo docker tag dev-share pangnem/dev-share:${GITHUB_SHA::7}
+          sudo docker push pangnem/dev-share:${GITHUB_SHA::7}
+
+      - name: Docker Deploy
+        uses: appleboy/ssh-action@master
+        with:
+          host: 13.125.238.228
+          username: ubuntu
+          key: ${{ secrets.PRIVATE_KEY }}
+          envs: GITHUB_SHA
+          script: |
+            sudo docker pull pangnem/dev-share:${GITHUB_SHA::7}
+            sudo docker tag pangnem/dev-share:${GITHUB_SHA::7} dev-share
+            sudo docker stop server
+            sudo docker run -d --rm --name server -p 8080:8080 dev-share


### PR DESCRIPTION
- docker를 이용하여 배포합니다.
- main 브랜치에 push, pull request 시 작동하도록 설정하였습니다.
- 만든 ec2 서버에 배포하도록 설정하였습니다.
	- 서버에서 ssh 키를 생성하고, private 키를 github의 secrets에 등록하였습니다.

See Also:
- https://github.com/PangNem/cicd-example
- https://itcoin.tistory.com/685?category=769089