### PR TITLE
fix: 배포 파일 이름 app.jar로 변경

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,6 @@ RUN ["./gradlew", "assemble"]
 
 FROM openjdk:11
 
-COPY --from=builder /build/libs/*.jar app.jar
+COPY --from=builder /build/libs/app.jar app.jar
 
 ENTRYPOINT ["java", "-jar", "app.jar"]
-
-

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,11 @@ plugins {
 	id 'java'
 }
 
+bootJar {
+	archivesBaseName = 'app'
+	archiveFileName = 'app.jar'
+}
+
 group = 'io'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'


### PR DESCRIPTION
#4 에서 배포 파일이 여러개를 `app.jar` 이름으로 복사를 시도하다가 도커 빌드에 실패하였습니다.

배포될 파일 이름을 `app.jar`로 변경하고 이 파일만 복사하도록 수정하였습니다. 