### PR TITLE
ci: sudo 명령어 제거

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,10 @@ jobs:
 
       - name: Docker build
         run: |
-          sudo docker build -t dev-share .
-          sudo docker login -u ${{ secrets.USERNAME }} -p ${{ secrets.PASSWORD }}
-          sudo docker tag dev-share pangnem/dev-share:${GITHUB_SHA::7}
-          sudo docker push pangnem/dev-share:${GITHUB_SHA::7}
+          docker login -u ${{ secrets.USERNAME }} -p ${{ secrets.PASSWORD }}
+          docker build -t dev-share .
+          docker tag dev-share pangnem/dev-share:${GITHUB_SHA::7}
+          docker push pangnem/dev-share:${GITHUB_SHA::7}
 
       - name: Docker Deploy
         uses: appleboy/ssh-action@master
@@ -46,7 +46,7 @@ jobs:
           key: ${{ secrets.PRIVATE_KEY }}
           envs: GITHUB_SHA
           script: |
-            sudo docker pull pangnem/dev-share:${GITHUB_SHA::7}
-            sudo docker tag pangnem/dev-share:${GITHUB_SHA::7} dev-share
-            sudo docker stop server
-            sudo docker run -d --rm --name server -p 8080:8080 dev-share
+            docker pull pangnem/dev-share:${GITHUB_SHA::7}
+            docker tag pangnem/dev-share:${GITHUB_SHA::7} dev-share
+            docker stop server
+            docker run -d --rm --name server -p 8080:8080 dev-share


### PR DESCRIPTION
원격 서버에서 `sudo`를 쓰지 않고도 `docker` 명령어를 사용할 수 있도록 설정하였기 때문에, `sudo` 명령어를 제거합니다.

서버에서 사용한 명령어는 다음과 같습니다:
`sudo usermod -a -G docker ubuntu`