### PR TITLE
ci: 도커 로그인 방식 변경

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,18 +32,21 @@ jobs:
         run: ./gradlew test
 
       - name: Login to Docker Hub
+        if: github.ref == 'refs/heads/main'
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.USERNAME }}
           password: ${{ secrets.PASSWORD }}
 
       - name: Docker build
+        if: github.ref == 'refs/heads/main'
         run: |
           docker build -t dev-share .
           docker tag dev-share pangnem/dev-share:${GITHUB_SHA::7}
           docker push pangnem/dev-share:${GITHUB_SHA::7}
 
       - name: Docker Deploy
+        if: github.ref == 'refs/heads/main'
         uses: appleboy/ssh-action@master
         with:
           host: 13.125.238.228

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,14 @@ jobs:
       - name: Gradle Test
         run: ./gradlew test
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.USERNAME }}
+          password: ${{ secrets.PASSWORD }}
+
       - name: Docker build
         run: |
-          docker login -u ${{ secrets.USERNAME }} -p ${{ secrets.PASSWORD }}
           docker build -t dev-share .
           docker tag dev-share pangnem/dev-share:${GITHUB_SHA::7}
           docker push pangnem/dev-share:${GITHUB_SHA::7}


### PR DESCRIPTION
명령어를 통한 도커 로그인 방식은 TTY 오류가 있어 이 actions로 대체합니다.

See Also:
- https://github.com/marketplace/actions/docker-login