### PR TITLE
build: Docker 빈 AWS 설정 파일 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM openjdk:11 AS builder
 
 COPY . .
 
+RUN ["touch", "src/main/resources/aws.yml"]
+
 RUN ["./gradlew", "assemble"]
 
 FROM openjdk:11


### PR DESCRIPTION
현재는 `aws.yml` 파일이 `.gitignore`에 등록되어 있어, EC2에 배포할 경우 해당 파일을 찾을 수 없어 서버 실행에 실패합니다.
따라서 도커에 빈 `aws.yml` 파일을 넣도록 설정하였습니다.