### PR TITLE
feat: InMemory ImagePost 구현

### DIFF
--- a/src/main/java/io/devshare/domain/ImagePostRepository.java
+++ b/src/main/java/io/devshare/domain/ImagePostRepository.java
@@ -1,0 +1,9 @@
+package io.devshare.domain;
+
+import java.util.List;
+
+public interface ImagePostRepository {
+    List<ImagePost> findAll();
+
+    ImagePost save(ImagePost imagePost);
+}

--- a/src/main/java/io/devshare/infra/InMemoryImagePostRepository.java
+++ b/src/main/java/io/devshare/infra/InMemoryImagePostRepository.java
@@ -1,0 +1,25 @@
+package io.devshare.infra;
+
+import io.devshare.domain.ImagePost;
+import io.devshare.domain.ImagePostRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Repository
+public class InMemoryImagePostRepository implements ImagePostRepository {
+    private List<ImagePost> imagePosts = new ArrayList<>();
+
+    @Override
+    public List<ImagePost> findAll() {
+        return imagePosts;
+    }
+
+    @Override
+    public ImagePost save(ImagePost imagePost) {
+        imagePosts.add(imagePost);
+
+        return imagePost;
+    }
+}

--- a/src/test/java/io/devshare/infra/InMemoryImagePostRepositoryTest.java
+++ b/src/test/java/io/devshare/infra/InMemoryImagePostRepositoryTest.java
@@ -1,0 +1,31 @@
+package io.devshare.infra;
+
+import io.devshare.domain.ImagePost;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InMemoryImagePostRepositoryTest {
+
+    private InMemoryImagePostRepository inMemoryImagePostRepository;
+
+    @BeforeEach
+    void setUp() {
+        inMemoryImagePostRepository = new InMemoryImagePostRepository();
+    }
+
+    @Test
+    @DisplayName("save 메서드는 이미지 포스트를 저장한다")
+    void save_test() {
+        ImagePost imagePost = ImagePost.createImagePostFrom("imagePost");
+        assertThat(inMemoryImagePostRepository.findAll())
+                .hasSize(0);
+
+        inMemoryImagePostRepository.save(imagePost);
+
+        assertThat(inMemoryImagePostRepository.findAll())
+                .hasSize(1);
+    }
+}


### PR DESCRIPTION
메모리 상에서 ImagePost를 저장할 저장소를 구현합니다.