### PR TITLE
feat: 이미지 포스트 보기 구현

### DIFF
--- a/src/main/java/io/devshare/application/ImagePostService.java
+++ b/src/main/java/io/devshare/application/ImagePostService.java
@@ -1,0 +1,24 @@
+package io.devshare.application;
+
+import io.devshare.domain.ImagePost;
+import io.devshare.domain.ImagePostRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ImagePostService {
+    private ImagePostRepository imagePostRepository;
+
+    public ImagePostService(ImagePostRepository imagePostRepository) {
+        this.imagePostRepository = imagePostRepository;
+    }
+
+    public List<ImagePost> getAllImagePosts() {
+        return imagePostRepository.findAll();
+    }
+
+    public ImagePost add(ImagePost imagePost) {
+        return imagePostRepository.save(imagePost);
+    }
+}

--- a/src/main/java/io/devshare/application/S3Uploader.java
+++ b/src/main/java/io/devshare/application/S3Uploader.java
@@ -4,6 +4,7 @@ import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import io.devshare.domain.ImagePost;
+import io.devshare.domain.ImagePostRepository;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
@@ -16,9 +17,11 @@ import java.util.UUID;
 public class S3Uploader {
 
     private final AmazonS3Client amazonS3Client;
+    private final ImagePostRepository imagePostRepository;
 
-    public S3Uploader(AmazonS3Client amazonS3Client) {
+    public S3Uploader(AmazonS3Client amazonS3Client, ImagePostRepository imagePostRepository) {
         this.amazonS3Client = amazonS3Client;
+        this.imagePostRepository = imagePostRepository;
     }
 
     @Value("${cloud.aws.s3.bucket.name}")
@@ -50,6 +53,8 @@ public class S3Uploader {
 
         String url = amazonS3Client.getUrl(bucketName, key).toString();
         imagePost.upload(url);
+
+        imagePostRepository.save(imagePost);
 
         return url;
     }

--- a/src/main/java/io/devshare/controllers/IndexController.java
+++ b/src/main/java/io/devshare/controllers/IndexController.java
@@ -1,7 +1,9 @@
 package io.devshare.controllers;
 
+import io.devshare.application.ImagePostService;
 import io.devshare.application.S3Uploader;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -14,13 +16,17 @@ import java.io.IOException;
 public class IndexController {
 
     private S3Uploader s3Uploader;
+    private ImagePostService imagePostService;
 
-    public IndexController(S3Uploader s3Uploader) {
+    public IndexController(S3Uploader s3Uploader, ImagePostService imagePostService) {
         this.s3Uploader = s3Uploader;
+        this.imagePostService = imagePostService;
     }
 
     @GetMapping("")
-    public String index() {
+    public String index(Model model) {
+        model.addAttribute("ImagePosts", imagePostService.getAllImagePosts());
+
         return "index";
     }
 

--- a/src/main/java/io/devshare/infra/CustomHelper.java
+++ b/src/main/java/io/devshare/infra/CustomHelper.java
@@ -1,0 +1,47 @@
+package io.devshare.infra;
+
+import com.github.jknack.handlebars.Options;
+import org.springframework.stereotype.Component;
+import pl.allegro.tech.boot.autoconfigure.handlebars.HandlebarsHelper;
+
+import java.io.IOException;
+
+/**
+ * Handlebars Build-in 헬퍼 외의 사용자 지정 헬퍼
+ */
+@Component
+@HandlebarsHelper
+public class CustomHelper {
+
+    /**
+     * 정수형 i가 3으로 나누어 떨어지면 fn(참)을 리턴, 아닐 경우 inverse(거짓)를 리턴합니다.
+     *
+     * @param i       정수형
+     * @param options Handlebars 옵션
+     * @return 정수형 i가 3으로 나누어 떨어지면 fn(참)을 리턴, 아닐 경우 inverse(거짓)를 리턴
+     * @throws IOException
+     */
+    public CharSequence isMultipleOfThree(int i, Options options) throws IOException {
+        if (i % 3 == 0) {
+            return options.fn(i);
+        }
+
+        return options.inverse(i);
+    }
+
+    /**
+     * 정수형 i가 1을 더한 값이 3으로 나누어 떨어지면 fn(참)을 리턴, 아닐 경우 inverse(거짓)를 리턴합니다.
+     *
+     * @param i       정수형
+     * @param options Handlebars 옵션
+     * @return 정수형 i가 1을 더한 값이 3으로 나누어 떨어지면 fn(참)을 리턴, 아닐 경우 inverse(거짓)를 리턴
+     * @throws IOException
+     */
+    public CharSequence isPlusOneMultipleOfThree(int i, Options options) throws IOException {
+        if ((i + 1) % 3 == 0) {
+            return options.fn(i);
+        }
+
+        return options.inverse(i);
+    }
+}

--- a/src/main/resources/templates/index.hbs
+++ b/src/main/resources/templates/index.hbs
@@ -96,6 +96,30 @@
 
 </header>
 
+<main>
+    {{#each ImagePosts}}
+        {{#isMultipleOfThree @index}}
+            <div class="d-flex justify-content-center align-items-center m-4"/>
+        {{/isMultipleOfThree}}
+        <div
+                class="bg-image d-flex justify-content-end align-items-end m-4"
+                style="
+                        background-image: url('{{url}}');
+                        height: 33vh;
+                        width: 33vh;
+                        "
+        >
+            <p class="text-white m-2" style="text-shadow: 2px 2px 4px #000000;">
+                {{uploader}}
+            </p>
+        </div>
+        {{#isPlusOneMultipleOfThree @index}}
+            </div>
+        {{/isPlusOneMultipleOfThree}}
+    {{/each}}
+</main>
+
+<!-- Background image -->
 <footer class="text-center text-white fixed-bottom fixed-bottom" style="background-color: #f1f1f1;">
     <!-- Grid container -->
     <div class="container pt-4">

--- a/src/test/java/io/devshare/application/ImagePostServiceTest.java
+++ b/src/test/java/io/devshare/application/ImagePostServiceTest.java
@@ -1,0 +1,40 @@
+package io.devshare.application;
+
+import io.devshare.domain.ImagePost;
+import io.devshare.infra.InMemoryImagePostRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ImagePostServiceTest {
+    private ImagePostService imagePostService;
+
+    @BeforeEach
+    void setUp() {
+        imagePostService = new ImagePostService(new InMemoryImagePostRepository());
+
+        imagePostService.add(ImagePost.createImagePostFrom("uploaderName"));
+    }
+
+    @Test
+    @DisplayName("getAllImagePosts 메서드는 모든 ImagePost를 반환한다")
+    void getAllImagePosts() {
+        List<ImagePost> allImagePosts = imagePostService.getAllImagePosts();
+
+        assertThat(allImagePosts).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("add 메서드는 ImagePost를 추가한다")
+    void add() {
+        ImagePost imagePost = ImagePost.createImagePostFrom("uploaderName");
+
+        imagePostService.add(imagePost);
+
+        assertThat(imagePostService.getAllImagePosts()).hasSize(2);
+    }
+}

--- a/src/test/java/io/devshare/application/S3UploaderTest.java
+++ b/src/test/java/io/devshare/application/S3UploaderTest.java
@@ -2,6 +2,7 @@ package io.devshare.application;
 
 
 import com.amazonaws.services.s3.AmazonS3Client;
+import io.devshare.infra.InMemoryImagePostRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -34,7 +35,7 @@ class S3UploaderTest {
     @BeforeEach
     void setUp() {
         amazonS3Client = mock(AmazonS3Client.class);
-        s3Uploader = new S3Uploader(amazonS3Client);
+        s3Uploader = new S3Uploader(amazonS3Client, new InMemoryImagePostRepository());
     }
 
     @Test


### PR DESCRIPTION
메인 페이지에서 업로드한 이미지를 볼 수 있도록 구현하였습니다.
- ImagePostService 구현 및 연결
- 메인 화면 구성
  - 사용자 지정 커스텀 헬퍼 사용
  
현재는 메모리 상의 데이터를 사용하고 있어, 서버가 꺼지면 데이터도 이미지 포스트도 사라지게 됩니다. 이 부분은 JPA를 활용한 영속화를 도입해야 합니다.