### PR TITLE
build: mustache 의존성 제거

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,6 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-devtools'
 
-    implementation 'org.springframework.boot:spring-boot-starter-mustache'
-
     // AWS
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.0.1.RELEASE'
 


### PR DESCRIPTION
- 이제 `handlebars`를 사용하기 때문에 더이상 필요하지 않습니다.