### PR TITLE
refactor: 파일 업로드 시 서버에 파일 생성 및 삭제 과정 제거

### DIFF
--- a/src/main/java/io/devshare/application/S3Uploader.java
+++ b/src/main/java/io/devshare/application/S3Uploader.java
@@ -1,11 +1,11 @@
 package io.devshare.application;
 
 import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.UUID;
 
@@ -27,38 +27,24 @@ public class S3Uploader {
     /**
      * 파일을 S3 저장소에 업로드 후, 저장한 URL을 리턴합니다.
      *
-     * @param mfile 멀티파트 파일
+     * @param multipartFile 멀티파트 파일
      * @return 업로드한 파일 URL
      * @throws IOException 멀티파트 파일 변환에 실패한 경우
      */
-    public String upload(MultipartFile mfile) throws IOException {
-        File convertedFile = convert(mfile);
+    public String upload(MultipartFile multipartFile) throws IOException {
+        String fileName = getFileName(multipartFile);
+        String key = getKey(fileName);
 
-        String key = getKey(convertedFile);
-        amazonS3Client.putObject(bucketName, key, convertedFile);
-
-        convertedFile.delete();
+        amazonS3Client.putObject(bucketName, key, multipartFile.getInputStream(), new ObjectMetadata());
 
         return amazonS3Client.getUrl(bucketName, key).toString();
     }
 
-    private String getKey(File file) {
-        return bucketImageDir + "/" + UUID.randomUUID() + file.getName();
+    private String getFileName(MultipartFile mfile) {
+        return System.getProperty("user.dir") + "/" + mfile.getOriginalFilename();
     }
 
-    /**
-     * 멀티파트 파일을 일반 파일 객체로 변환합니다.
-     *
-     * @param mfile 멀티파트 파일
-     * @return 변환된 일반 파일 객체
-     * @throws IOException 멀티파트 파일 변환에 실패한 경우
-     */
-    private File convert(MultipartFile mfile) throws IOException {
-        String fileName = System.getProperty("user.dir") + "/" + mfile.getOriginalFilename();
-        File file = new File(fileName);
-
-        mfile.transferTo(file);
-
-        return file;
+    private String getKey(String fileName) {
+        return bucketImageDir + "/" + UUID.randomUUID() + fileName;
     }
 }

--- a/src/test/java/io/devshare/application/S3UploaderTest.java
+++ b/src/test/java/io/devshare/application/S3UploaderTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockMultipartFile;
 
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URL;
@@ -52,7 +51,5 @@ class S3UploaderTest {
         String url = s3Uploader.upload(file);
 
         assertThat(url).isEqualTo(IMAGE_URL);
-
-        file.transferTo(new File(FILENAME));
     }
 }


### PR DESCRIPTION
- 기존에는 S3에 파일 업로드 전 서버에 파일 생성, 해당 파일 정보 읽기, 파일 삭제 등을 하였습니다.
- 이제는 업로드 시 멀티파트 파일에서 InputStream으로 바로 업로드 합니다.
- 이에 따라 테스트 코드 마지막에는 더이상 파일을 재생성 하지 않습니다.